### PR TITLE
feature: 新增长句丢失换行检测与 skip_check 跳过检查 (#205)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ desktop/src-tauri/target/
 app_settings.json
 /release/
 /.venv-build/
+
+# Virtual environments
+venv/
+.venv/
+
 galtransl_backend.spec
 /build
 /dist

--- a/GalTransl/CSentense.py
+++ b/GalTransl/CSentense.py
@@ -39,6 +39,7 @@ class CSentense:
         self.proofread_by = ""  # 校对记录
 
         self.problem = ""  # 问题记录
+        self.skip_check = False  # 跳过问题检查
         self.trans_conf = 0.0  # 翻译可信度 For GPT4
         self.doub_content = ""  # 用于记录疑问句的内容 For GPT4
         self.unknown_proper_noun = ""  # 用于记录未知的专有名词 For GPT4

--- a/GalTransl/Cache.py
+++ b/GalTransl/Cache.py
@@ -134,6 +134,9 @@ def _build_cache_obj(tran, post_save: bool = False):
     if post_save and tran.problem != "":
         cache_obj["problem"] = tran.problem
 
+    if tran.skip_check:
+        cache_obj["skip_check"] = True
+
     cache_obj["trans_by"] = tran.trans_by
     cache_obj["proofread_by"] = tran.proofread_by
 
@@ -501,6 +504,8 @@ async def get_transCache_from_json(
             tran.doub_content = cache_dict[cache_key]["doub_content"]
         if "unknown_proper_noun" in cache_dict[cache_key]:
             tran.unknown_proper_noun = cache_dict[cache_key]["unknown_proper_noun"]
+        if "skip_check" in cache_dict[cache_key]:
+            tran.skip_check = cache_dict[cache_key]["skip_check"]
 
         if tran.proofread_zh != "":
             tran.post_dst = tran.proofread_zh

--- a/GalTransl/ConfigHelper.py
+++ b/GalTransl/ConfigHelper.py
@@ -109,6 +109,7 @@ class CProblemType(Enum):
     语言不通 = 10
     缺控制符 = 11
     独白男他 = 12
+    长句丢失换行 = 13
 
 
 class CProjectConfig:
@@ -240,6 +241,11 @@ class CProjectConfig:
         elif not self.projectConfig["problemAnalyze"]["arinashiDict"]:
             return {}
         return self.projectConfig["problemAnalyze"]["arinashiDict"]
+
+    def getAvgSentenceLengthThreshold(self) -> int:
+        return self.projectConfig.get("problemAnalyze", {}).get(
+            "avgSentenceLengthThreshold", 10
+        )
 
     def refreshProxyEnabledFlag(self) -> None:
         self.keyValues["internals.enableProxy"] = has_usable_proxy_config(

--- a/GalTransl/ConfigHelper.py
+++ b/GalTransl/ConfigHelper.py
@@ -243,9 +243,15 @@ class CProjectConfig:
         return self.projectConfig["problemAnalyze"]["arinashiDict"]
 
     def getAvgSentenceLengthThreshold(self) -> int:
-        return self.projectConfig.get("problemAnalyze", {}).get(
-            "avgSentenceLengthThreshold", 10
+        raw = self.projectConfig.get("problemAnalyze", {}).get(
+            "avgSentenceLengthThreshold", 17
         )
+        # 强制转为 int：用户手改 config.yaml 可能写成 "17"(字符串)
+        # 或 17.5(浮点)，直接返回会导致后端 compare 时抛 TypeError。
+        try:
+            return int(round(float(raw)))
+        except (TypeError, ValueError):
+            return 17
 
     def refreshProxyEnabledFlag(self) -> None:
         self.keyValues["internals.enableProxy"] = has_usable_proxy_config(

--- a/GalTransl/DefaultProjectConfig.py
+++ b/GalTransl/DefaultProjectConfig.py
@@ -95,6 +95,8 @@ problemAnalyze:
     - 独白男他 # 独白（无name）里出现“他”，排除“其他/他们/他人/他乡/他国/他日/他山”
     #- 引入英文 # 本来没有英文，译文引入了英文
     #- 比日文长严格 # 比日文长1倍以上就提醒
+    #- 长句丢失换行 # 平均分句长度低于阈值（avgSentenceLengthThreshold），缺少应有换行
+  avgSentenceLengthThreshold: 10 # 长句丢失换行的分句长度阈值，默认10，一般8~15
 
 # 字典设置
 dictionary:

--- a/GalTransl/DefaultProjectConfig.py
+++ b/GalTransl/DefaultProjectConfig.py
@@ -95,8 +95,8 @@ problemAnalyze:
     - 独白男他 # 独白（无name）里出现“他”，排除“其他/他们/他人/他乡/他国/他日/他山”
     #- 引入英文 # 本来没有英文，译文引入了英文
     #- 比日文长严格 # 比日文长1倍以上就提醒
-    #- 长句丢失换行 # 平均分句长度低于阈值（avgSentenceLengthThreshold），缺少应有换行
-  avgSentenceLengthThreshold: 10 # 长句丢失换行的分句长度阈值，默认10，一般8~15
+    #- 长句丢失换行 # 平均分句长度超过阈值（avgSentenceLengthThreshold），缺少应有换行
+  avgSentenceLengthThreshold: 17 # 长句丢失换行的分句长度阈值，默认17，建议范围15~25
 
 # 字典设置
 dictionary:

--- a/GalTransl/Problem.py
+++ b/GalTransl/Problem.py
@@ -47,6 +47,9 @@ def find_problems(
         find_type = projectConfig.getProblemAnalyzeConfig("GPT35")  # 兼容旧版
 
     for tran in trans_list:
+        if getattr(tran, "skip_check", False):
+            continue
+
         pre_src = tran.pre_src
         post_src = tran.post_src
         pre_dst = tran.pre_dst
@@ -106,7 +109,12 @@ def find_problems(
             if pre_dst_jp_chars != "" and post_dst_jp_chars != "":
                 problem_list.append(f"残留日文：{post_dst_jp_chars}")
         if CProblemType.丢失换行 in find_type and n_symbol != "":
-            if pre_src.count(n_symbol) > post_dst.count(n_symbol):
+            # 当译文很短（<18字符）时，原文的换行符通常是因日文冗长而非语义需要，
+            # 译文无需保留这些换行，跳过检测。
+            # 当原文长度远超译文（>3倍）时同理，原文换行多因文本长而非结构需要。
+            if len(post_dst) < 18 or len(pre_src) > len(post_dst) * 3:
+                pass
+            elif pre_src.count(n_symbol) > post_dst.count(n_symbol):
                 problem_list.append("丢失换行")
         if CProblemType.多加换行 in find_type and n_symbol != "":
             if pre_src.count(n_symbol) < post_dst.count(n_symbol):

--- a/GalTransl/Problem.py
+++ b/GalTransl/Problem.py
@@ -109,13 +109,22 @@ def find_problems(
             if pre_dst_jp_chars != "" and post_dst_jp_chars != "":
                 problem_list.append(f"残留日文：{post_dst_jp_chars}")
         if CProblemType.丢失换行 in find_type and n_symbol != "":
-            # 当译文很短（<18字符）时，原文的换行符通常是因日文冗长而非语义需要，
-            # 译文无需保留这些换行，跳过检测。
-            # 当原文长度远超译文（>3倍）时同理，原文换行多因文本长而非结构需要。
-            if len(post_dst) < 18 or len(pre_src) > len(post_dst) * 3:
-                pass
-            elif pre_src.count(n_symbol) > post_dst.count(n_symbol):
+            if pre_src.count(n_symbol) > post_dst.count(n_symbol):
                 problem_list.append("丢失换行")
+        if CProblemType.长句丢失换行 in find_type and n_symbol != "":
+            n_number = max(post_dst.count(n_symbol), 1)
+            translation_len = len(post_dst)
+            avg_sentence_length = translation_len / n_number
+            threshold = projectConfig.getAvgSentenceLengthThreshold()
+            if avg_sentence_length < threshold:
+                problem_list.append("长句丢失换行")
+        if CProblemType.长句丢失换行 in find_type and n_symbol != "":
+            n_number = max(post_dst.count(n_symbol), 1)
+            translation_len = len(post_dst)
+            avg_sentence_length = translation_len / n_number
+            threshold = projectConfig.getAvgSentenceLengthThreshold()
+            if avg_sentence_length < threshold:
+                problem_list.append("长句丢失换行")
         if CProblemType.多加换行 in find_type and n_symbol != "":
             if pre_src.count(n_symbol) < post_dst.count(n_symbol):
                 problem_list.append("多加换行")

--- a/GalTransl/Problem.py
+++ b/GalTransl/Problem.py
@@ -48,6 +48,7 @@ def find_problems(
 
     for tran in trans_list:
         if getattr(tran, "skip_check", False):
+            tran.problem = ""
             continue
 
         pre_src = tran.pre_src
@@ -112,18 +113,12 @@ def find_problems(
             if pre_src.count(n_symbol) > post_dst.count(n_symbol):
                 problem_list.append("丢失换行")
         if CProblemType.长句丢失换行 in find_type and n_symbol != "":
-            n_number = max(post_dst.count(n_symbol), 1)
-            translation_len = len(post_dst)
-            avg_sentence_length = translation_len / n_number
+            n_number = post_dst.count(n_symbol)
+            # 去除换行符本身的字符长度，只计算纯文本
+            clean_len = len(post_dst) - n_number * len(n_symbol)
+            avg_sentence_length = clean_len / (n_number + 1)
             threshold = projectConfig.getAvgSentenceLengthThreshold()
-            if avg_sentence_length < threshold:
-                problem_list.append("长句丢失换行")
-        if CProblemType.长句丢失换行 in find_type and n_symbol != "":
-            n_number = max(post_dst.count(n_symbol), 1)
-            translation_len = len(post_dst)
-            avg_sentence_length = translation_len / n_number
-            threshold = projectConfig.getAvgSentenceLengthThreshold()
-            if avg_sentence_length < threshold:
+            if avg_sentence_length > threshold:
                 problem_list.append("长句丢失换行")
         if CProblemType.多加换行 in find_type and n_symbol != "":
             if pre_src.count(n_symbol) < post_dst.count(n_symbol):

--- a/GalTransl/server.py
+++ b/GalTransl/server.py
@@ -1053,6 +1053,7 @@ def build_handler(registry: JobRegistry):
                             s.trans_conf = e.get("trans_conf", 0)
                             s.doub_content = e.get("doub_content", "")
                             s.unknown_proper_noun = e.get("unknown_proper_noun", "")
+                            s.skip_check = bool(e.get("skip_check", False))
                             trans_list.append(s)
 
                         # Link prev/next

--- a/GalTransl/server.py
+++ b/GalTransl/server.py
@@ -428,6 +428,7 @@ _PROBLEM_TYPE_CATALOG: list[dict[str, str]] = [
     {"name": "语言不通", "description": "译文包含大量非 GBK 字符（仅对中文目标语言生效）。"},
     {"name": "缺控制符", "description": "译文缺少原文中的控制符（如 \\n、变量标记等）。"},
     {"name": "独白男他", "description": "独白（无name）译文出现'他'。"},
+    {"name": "长句丢失换行", "description": "译文平均分句长度低于阈值，可能缺少应有的换行。"},
 ]
 
 

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -104,6 +104,7 @@ export type CacheEntry = {
   trans_by?: string;
   proofread_by?: string;
   problem?: string;
+  skip_check?: boolean;
   trans_conf?: number;
   doub_content?: string;
   unknown_proper_noun?: string;

--- a/desktop/src/pages/ProjectCachePage.tsx
+++ b/desktop/src/pages/ProjectCachePage.tsx
@@ -82,7 +82,7 @@ function CacheEntryCard({
   entry: CacheEntry;
   filename: string;
   projectId: string;
-  onEntryChange: (index: number, field: keyof CacheEntry, value: string) => void;
+  onEntryChange: (index: number, field: keyof CacheEntry, value: string | boolean) => void;
   onDelete: (index: number) => void;
   highlightQuery?: string;
   nameDict: Map<string, string>;
@@ -109,6 +109,9 @@ function CacheEntryCard({
           </div>
         )}
         <div className="cache-card__spacer" />
+        {entry.skip_check && (
+          <span className="cache-card__pill cache-card__pill--skip-check" title="已跳过问题检查">⏭</span>
+        )}
         {entry.trans_by && (
           <span className="cache-card__pill cache-card__pill--engine">{entry.trans_by}</span>
         )}
@@ -205,6 +208,16 @@ function CacheEntryCard({
               <div className="cache-card__readonly-textarea">
                 {escapeControlChars(entry.post_dst_preview || entry.post_zh_preview || '')}
               </div>
+            </div>
+            <div className="cache-card__field cache-card__field--skip-check">
+              <label className="cache-card__checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={!!entry.skip_check}
+                  onChange={(e) => onEntryChange(entry.index, 'skip_check', e.target.checked)}
+                />
+                <span>跳过检查（skip_check）</span>
+              </label>
             </div>
           </>
         )}
@@ -769,9 +782,17 @@ export function ProjectCachePage({ ctx, active = true }: { ctx: ProjectPageConte
   const translated = entries.filter((e) => dst(e)).length;
   const withProblems = entries.filter((e) => e.problem).length;
 
-  const handleEntryChange = (index: number, field: keyof CacheEntry, value: string) => {
+  const handleEntryChange = (index: number, field: keyof CacheEntry, value: string | boolean) => {
     setEntries((prev) => {
-      const next = prev.map((e) => (e.index === index ? { ...e, [field]: value } : e));
+      const next = prev.map((e) => {
+        if (e.index !== index) return e;
+        const updated = { ...e, [field]: value };
+        // 勾选跳过检查时同步清除问题标记
+        if (field === 'skip_check' && value === true) {
+          updated.problem = '';
+        }
+        return updated;
+      });
       if (selectedFile) entriesMapRef.current.set(selectedFile, next);
       return next;
     });

--- a/desktop/src/pages/ProjectConfigPage.tsx
+++ b/desktop/src/pages/ProjectConfigPage.tsx
@@ -376,6 +376,13 @@ export function ProjectConfigPage({ ctx }: { ctx: ProjectPageContext }) {
                       return prev ? { ...prev, problemAnalyze: pa } : prev;
                     });
                   }}
+                  onThresholdChange={(value) => {
+                    setConfig((prev) => {
+                      const pa = { ...((prev?.problemAnalyze as Record<string, unknown>) || {}) };
+                      pa.avgSentenceLengthThreshold = value;
+                      return prev ? { ...prev, problemAnalyze: pa } : prev;
+                    });
+                  }}
                   onDirty={() => { setSaveSuccess(false); setDirty(true); }}
                 />
               )}

--- a/desktop/src/pages/project-config/ProblemAnalyzeSection.tsx
+++ b/desktop/src/pages/project-config/ProblemAnalyzeSection.tsx
@@ -5,6 +5,7 @@ import { fetchProblemTypes, type ProblemTypeInfo } from '../../lib/api';
 interface ProblemAnalyzeSectionProps {
   config: Record<string, unknown> | null;
   onProblemListChange: (lines: string[]) => void;
+  onThresholdChange: (value: number) => void;
   onDirty: () => void;
 }
 
@@ -20,7 +21,7 @@ function readProblemList(config: Record<string, unknown> | null): string[] {
   return [];
 }
 
-export function ProblemAnalyzeSection({ config, onProblemListChange, onDirty }: ProblemAnalyzeSectionProps) {
+export function ProblemAnalyzeSection({ config, onProblemListChange, onThresholdChange, onDirty }: ProblemAnalyzeSectionProps) {
   const [problemTypes, setProblemTypes] = useState<ProblemTypeInfo[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -43,6 +44,41 @@ export function ProblemAnalyzeSection({ config, onProblemListChange, onDirty }: 
 
   const selected = useMemo(() => readProblemList(config), [config]);
   const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const threshold = useMemo(() => {
+    const pa = (config?.problemAnalyze as Record<string, unknown>) || {};
+    const raw = pa.avgSentenceLengthThreshold;
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+    return 17;
+  }, [config]);
+
+  // 本地输入态：保留用户输入的原始字符串（含空串 / 非整数等中间态），
+  // 以便对阈值类型做实时检测与提示，而不是直接吞掉非法输入。
+  const [thresholdInput, setThresholdInput] = useState<string>(String(threshold));
+  const [thresholdError, setThresholdError] = useState<string | null>(null);
+
+  // 外部 config 变化（载入 / 重置）时同步本地输入态。
+  useEffect(() => {
+    setThresholdInput(String(threshold));
+    setThresholdError(null);
+  }, [threshold]);
+
+  const validateAndCommitThreshold = (raw: string) => {
+    setThresholdInput(raw);
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      setThresholdError('阈值不能为空，请输入大于 0 的整数');
+      return;
+    }
+    const v = Number(trimmed);
+    if (!Number.isInteger(v) || v <= 0) {
+      setThresholdError('阈值类型无效：请输入大于 0 的整数');
+      return;
+    }
+    setThresholdError(null);
+    onThresholdChange(v);
+    onDirty();
+  };
 
   // Keep entries the user already has in config even if backend doesn't list them
   // (e.g. future types or custom strings); render them at the bottom.
@@ -172,6 +208,29 @@ export function ProblemAnalyzeSection({ config, onProblemListChange, onDirty }: 
                 </li>
               ))}
             </ul>
+
+            <div className="problem-analyze-section__threshold">
+              <label className="problem-analyze-section__threshold-label">
+                <span>长句判定阈值（avgSentenceLengthThreshold）</span>
+                <input
+                  type="number"
+                  className={`problem-analyze-section__threshold-input${thresholdError ? ' problem-analyze-section__threshold-input--error' : ''}`}
+                  min={1}
+                  max={99}
+                  value={thresholdInput}
+                  onChange={(e) => validateAndCommitThreshold(e.target.value)}
+                  onBlur={(e) => validateAndCommitThreshold(e.target.value)}
+                />
+              </label>
+              <span className="problem-analyze-section__threshold-desc">
+                译文平均分句长度超过此值时标记为"长句丢失换行"。默认 17，建议范围 15~25。
+              </span>
+              {thresholdError && (
+                <span className="problem-analyze-section__threshold-error">
+                  {thresholdError}
+                </span>
+              )}
+            </div>
           </>
         )}
       </div>

--- a/desktop/src/styles/pages/project-cache.css
+++ b/desktop/src/styles/pages/project-cache.css
@@ -557,6 +557,13 @@
   white-space: nowrap;
 }
 
+.cache-card__pill--skip-check {
+  background: var(--color-success-soft, #d4edda);
+  color: var(--color-success, #155724);
+  flex-shrink: 0;
+  font-size: var(--cache-font-xs);
+}
+
 .cache-card__expand,
 .cache-card__delete {
   flex-shrink: 0;
@@ -726,6 +733,24 @@
   cursor: default;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.cache-card__field--skip-check {
+  padding: var(--space-1) var(--space-2);
+}
+
+.cache-card__checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  font-size: var(--cache-font-xs);
+  color: var(--color-text-secondary);
+  user-select: none;
+}
+
+.cache-card__checkbox-label input[type="checkbox"] {
+  cursor: pointer;
 }
 
 .cache-panel-actions {

--- a/desktop/src/styles/pages/project-config.css
+++ b/desktop/src/styles/pages/project-config.css
@@ -507,6 +507,67 @@
   border-color: rgba(47, 111, 235, 0.65);
 }
 
+/* ── 长句判定阈值输入 ── */
+
+.problem-analyze-section__threshold {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-line);
+}
+
+.problem-analyze-section__threshold-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.problem-analyze-section__threshold-input {
+  width: 72px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  text-align: center;
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.problem-analyze-section__threshold-input:focus {
+  border-color: rgba(47, 111, 235, 0.65);
+  box-shadow: 0 0 0 3px rgba(47, 111, 235, 0.2);
+}
+
+.problem-analyze-section__threshold-input--error {
+  border-color: #e5484d;
+  color: #e5484d;
+}
+
+.problem-analyze-section__threshold-input--error:focus {
+  border-color: #e5484d;
+  box-shadow: 0 0 0 3px rgba(229, 72, 77, 0.2);
+}
+
+.problem-analyze-section__threshold-error {
+  display: block;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: #e5484d;
+  line-height: 1.4;
+}
+
+.problem-analyze-section__threshold-desc {
+  display: block;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  line-height: 1.4;
+}
+
 .problem-analyze-section__checkbox:checked {
   background: var(--color-primary);
   border-color: var(--color-primary);

--- a/tests/test_cache_save_respects_skip_check.py
+++ b/tests/test_cache_save_respects_skip_check.py
@@ -1,0 +1,138 @@
+"""测试 /cache/save 端点的 rebuild 流程是否尊重 skip_check。
+
+复刻 server.py 中 /cache/save 的重建逻辑：
+  1. 从前端传来的 entries 构建 CSentense 列表（读取 skip_check）
+  2. 运行 find_problems
+  3. 将 problem / post_dst_preview 回写到 entries
+
+验证：勾选 skip_check 的句子在 rebuild 后不会被重新标记 problem。
+"""
+
+import unittest
+
+from GalTransl.CSentense import CSentense
+from GalTransl.Problem import find_problems
+
+
+class FakeProblemConfig:
+    """最小化的 projectConfig，用于驱动 find_problems。"""
+
+    target_lang = "zh-cn"
+
+    def __init__(self, problem_list=None, threshold=17):
+        self._problem_list = problem_list or ["长句丢失换行"]
+        self._threshold = threshold
+
+    def getProblemAnalyzeArinashiDict(self):
+        return {}
+
+    def getProblemAnalyzeConfig(self, key):
+        if key == "problemList":
+            # 转换成 CProblemType 枚举，find_problems 内部用 `enum in find_type`
+            from GalTransl.Problem import CProblemType
+            return [CProblemType[name] for name in self._problem_list]
+        return []
+
+    def getlbSymbol(self):
+        return "auto"
+
+    def getAvgSentenceLengthThreshold(self):
+        return self._threshold
+
+
+def rebuild_entries(entries, config):
+    """复刻 server.py /cache/save 的 rebuild 核心步骤。"""
+    trans_list = []
+    for e in entries:
+        speaker = e.get("name", "")
+        if isinstance(speaker, list):
+            speaker = "/".join(speaker)
+        pre_src = e.get("pre_src", "") or e.get("pre_jp", "")
+        post_src = e.get("post_src", "") or e.get("post_jp", "")
+        pre_dst = e.get("pre_dst", "") or e.get("pre_zh", "")
+        proofread_dst = e.get("proofread_dst", "") or e.get("proofread_zh", "")
+        if post_src == "":
+            continue
+        s = CSentense(pre_src, speaker if speaker else "", e.get("index", 0))
+        s.post_src = pre_src
+        s.pre_dst = pre_dst
+        s.proofread_zh = proofread_dst
+        s.post_dst = proofread_dst if proofread_dst else pre_dst
+        s.trans_by = e.get("trans_by", "")
+        s.proofread_by = e.get("proofread_by", "")
+        s.trans_conf = e.get("trans_conf", 0)
+        s.doub_content = e.get("doub_content", "")
+        s.unknown_proper_noun = e.get("unknown_proper_noun", "")
+        s.skip_check = bool(e.get("skip_check", False))
+        trans_list.append(s)
+
+    for i, s in enumerate(trans_list):
+        if i > 0:
+            s.prev_tran = trans_list[i - 1]
+        if i < len(trans_list) - 1:
+            s.next_tran = trans_list[i + 1]
+
+    if trans_list:
+        find_problems(trans_list, config, None)
+
+    idx = 0
+    for e in entries:
+        post_src_val = e.get("post_src", "") or e.get("post_jp", "")
+        if post_src_val == "":
+            continue
+        if idx < len(trans_list):
+            tran = trans_list[idx]
+            if tran.problem:
+                e["problem"] = tran.problem
+            elif "problem" in e:
+                del e["problem"]
+            e["post_dst_preview"] = tran.post_dst
+            idx += 1
+
+    return entries
+
+
+# 原文有换行，译文很长且无换行 → 会触发"长句丢失换行"
+SRC_WITH_BREAK = "日本語の長い文章です。\nもっと続きますよ。"
+DST_LONG_NO_BREAK = "这是一句非常长的中文翻译完全没有换行符来分割整句话。"
+
+
+class TestCacheSaveRespectsSkipCheck(unittest.TestCase):
+    def _make_entry(self, skip_check, problem=""):
+        return {
+            "index": 0,
+            "name": "",
+            "pre_src": SRC_WITH_BREAK,
+            "post_src": SRC_WITH_BREAK,
+            "pre_dst": DST_LONG_NO_BREAK,
+            "proofread_dst": DST_LONG_NO_BREAK,
+            "skip_check": skip_check,
+            "problem": problem,
+        }
+
+    def test_skip_check_prevents_rebuild_flagging(self):
+        """勾选 skip_check 的句子，rebuild 后不应被标记 problem。"""
+        entry = self._make_entry(skip_check=True, problem="")
+        entries = rebuild_entries([entry], FakeProblemConfig())
+        self.assertNotIn("problem", entries[0],
+                         "skip_check=True 时 rebuild 不应写回 problem")
+        self.assertTrue(entries[0]["skip_check"])
+
+    def test_no_skip_check_still_flagged(self):
+        """未勾选 skip_check 的同句，rebuild 后应被标记。"""
+        entry = self._make_entry(skip_check=False, problem="")
+        entries = rebuild_entries([entry], FakeProblemConfig())
+        self.assertIn("problem", entries[0])
+        self.assertIn("长句丢失换行", entries[0]["problem"])
+
+    def test_skip_check_clears_existing_problem(self):
+        """前端传来的 entry 带有旧 problem，勾选 skip_check 后 rebuild 清除它。"""
+        entry = self._make_entry(skip_check=True,
+                                 problem="长句丢失换行")
+        entries = rebuild_entries([entry], FakeProblemConfig())
+        self.assertNotIn("problem", entries[0],
+                         "skip_check=True 应清除已有的 problem 标记")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache_save_respects_skip_check.py
+++ b/tests/test_cache_save_respects_skip_check.py
@@ -1,13 +1,3 @@
-"""测试 /cache/save 端点的 rebuild 流程是否尊重 skip_check。
-
-复刻 server.py 中 /cache/save 的重建逻辑：
-  1. 从前端传来的 entries 构建 CSentense 列表（读取 skip_check）
-  2. 运行 find_problems
-  3. 将 problem / post_dst_preview 回写到 entries
-
-验证：勾选 skip_check 的句子在 rebuild 后不会被重新标记 problem。
-"""
-
 import unittest
 
 from GalTransl.CSentense import CSentense
@@ -15,8 +5,6 @@ from GalTransl.Problem import find_problems
 
 
 class FakeProblemConfig:
-    """最小化的 projectConfig，用于驱动 find_problems。"""
-
     target_lang = "zh-cn"
 
     def __init__(self, problem_list=None, threshold=17):
@@ -28,7 +16,6 @@ class FakeProblemConfig:
 
     def getProblemAnalyzeConfig(self, key):
         if key == "problemList":
-            # 转换成 CProblemType 枚举，find_problems 内部用 `enum in find_type`
             from GalTransl.Problem import CProblemType
             return [CProblemType[name] for name in self._problem_list]
         return []
@@ -41,7 +28,6 @@ class FakeProblemConfig:
 
 
 def rebuild_entries(entries, config):
-    """复刻 server.py /cache/save 的 rebuild 核心步骤。"""
     trans_list = []
     for e in entries:
         speaker = e.get("name", "")
@@ -92,7 +78,6 @@ def rebuild_entries(entries, config):
     return entries
 
 
-# 原文有换行，译文很长且无换行 → 会触发"长句丢失换行"
 SRC_WITH_BREAK = "日本語の長い文章です。\nもっと続きますよ。"
 DST_LONG_NO_BREAK = "这是一句非常长的中文翻译完全没有换行符来分割整句话。"
 
@@ -110,28 +95,22 @@ class TestCacheSaveRespectsSkipCheck(unittest.TestCase):
             "problem": problem,
         }
 
-    def test_skip_check_prevents_rebuild_flagging(self):
-        """勾选 skip_check 的句子，rebuild 后不应被标记 problem。"""
+    def test_skip_check_prevents_rebuild_flagging(self) -> None:
         entry = self._make_entry(skip_check=True, problem="")
         entries = rebuild_entries([entry], FakeProblemConfig())
-        self.assertNotIn("problem", entries[0],
-                         "skip_check=True 时 rebuild 不应写回 problem")
+        self.assertNotIn("problem", entries[0])
         self.assertTrue(entries[0]["skip_check"])
 
-    def test_no_skip_check_still_flagged(self):
-        """未勾选 skip_check 的同句，rebuild 后应被标记。"""
+    def test_no_skip_check_still_flagged(self) -> None:
         entry = self._make_entry(skip_check=False, problem="")
         entries = rebuild_entries([entry], FakeProblemConfig())
         self.assertIn("problem", entries[0])
         self.assertIn("长句丢失换行", entries[0]["problem"])
 
-    def test_skip_check_clears_existing_problem(self):
-        """前端传来的 entry 带有旧 problem，勾选 skip_check 后 rebuild 清除它。"""
-        entry = self._make_entry(skip_check=True,
-                                 problem="长句丢失换行")
+    def test_skip_check_clears_existing_problem(self) -> None:
+        entry = self._make_entry(skip_check=True, problem="长句丢失换行")
         entries = rebuild_entries([entry], FakeProblemConfig())
-        self.assertNotIn("problem", entries[0],
-                         "skip_check=True 应清除已有的 problem 标记")
+        self.assertNotIn("problem", entries[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_long_sentence_linebreak_detection.py
+++ b/tests/test_long_sentence_linebreak_detection.py
@@ -1,15 +1,3 @@
-"""测试"长句丢失换行"问题检测项。
-
-测试场景：
-- 译文分句过长（avg_sentence_length > threshold）应标记为"长句丢失换行"
-- 译文分句正常不应误标记
-- skip_check 可跳过该检测
-- 未启用该检测项时不触发
-
-设计前提：译文与原文使用同一种换行符（由 pre_src 推断的 n_symbol），
-因此检测直接复用 n_symbol 对 post_dst 计数，不处理"多换行符混用"场景。
-"""
-
 import unittest
 
 from GalTransl.Problem import find_problems
@@ -18,8 +6,6 @@ from GalTransl.CSentense import CSentense
 
 
 class FakeProblemConfig:
-    """最小化的 projectConfig，用于驱动 find_problems。"""
-
     target_lang = "zh-cn"
 
     def __init__(self, problem_list=None, threshold=17):
@@ -42,7 +28,6 @@ class FakeProblemConfig:
 
 
 def make_tran(pre_src: str, pre_dst: str, skip_check: bool = False) -> CSentense:
-    """构造一个 CSentense，原文带换行符以便触发检测。"""
     tran = CSentense(pre_src, speaker="", index=0)
     tran.post_src = pre_src
     tran.pre_dst = pre_dst
@@ -52,103 +37,79 @@ def make_tran(pre_src: str, pre_dst: str, skip_check: bool = False) -> CSentense
 
 
 class LongSentenceLinebreakDetectionTests(unittest.TestCase):
-    """长句丢失换行检测的单元测试。"""
 
-    def test_long_text_no_break_flagged(self):
-        """长译文且无换行符 → 平均分句长度 > 阈值 → 应标记。"""
-        # 原文带 \n 以便 n_symbol 被识别
+    def test_long_text_no_break_flagged(self) -> None:
         pre_src = "日本語の長い文章です。\nもっと続きます。"
-        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"  # clean_len=24, breaks=0, avg=24/1=24 > 17
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
         tran = make_tran(pre_src, pre_dst)
         config = FakeProblemConfig()
         find_problems([tran], config)
-        self.assertIn("长句丢失换行", tran.problem,
-                      "长译文无换行应被标记")
+        self.assertIn("长句丢失换行", tran.problem)
 
-    def test_short_text_no_break_not_flagged(self):
-        """短译文且无换行 → 平均分句长度 ≤ 阈值 → 不应标记。"""
+    def test_short_text_no_break_not_flagged(self) -> None:
         pre_src = "ああ。\nそうですか。"
-        pre_dst = "总之，能再试试其他的服装吗？"  # len=14, breaks=0, avg=14/1=14 ≤ 17
+        pre_dst = "总之，能再试试其他的服装吗？"
         tran = make_tran(pre_src, pre_dst)
         config = FakeProblemConfig()
         find_problems([tran], config)
-        self.assertNotIn("长句丢失换行", tran.problem,
-                         "短译文无换行不应标记")
+        self.assertNotIn("长句丢失换行", tran.problem)
 
-    def test_text_with_enough_breaks_not_flagged(self):
-        """译文有合理换行 → 平均分句长度正常 → 不应标记。"""
+    def test_text_with_enough_breaks_not_flagged(self) -> None:
         pre_src = "文A。\n文B。\n文C。"
-        pre_dst = "第一句。\n第二句。\n第三句。"  # len=14, clean=12, breaks=2, avg=12/3=4.0 ≤ 17
+        pre_dst = "第一句。\n第二句。\n第三句。"
         tran = make_tran(pre_src, pre_dst)
         config = FakeProblemConfig()
         find_problems([tran], config)
-        self.assertNotIn("长句丢失换行", tran.problem,
-                         "有合理换行的译文不应标记")
+        self.assertNotIn("长句丢失换行", tran.problem)
 
-    def test_custom_threshold_affects_result(self):
-        """自定义更紧的阈值 → 之前不触发的场景现在触发。"""
+    def test_custom_threshold_affects_result(self) -> None:
         pre_src = "文。\n文。"
-        pre_dst = "合理长度的句子。\n另一句。\n再来一句。"  # len=19, clean=17, breaks=2, avg=17/3≈5.67
+        pre_dst = "合理长度的句子。\n另一句。\n再来一句。"
         tran = make_tran(pre_src, pre_dst)
-        # 阈值设为 5，avg=5.67 > 5，应标记
         config = FakeProblemConfig(threshold=5)
         find_problems([tran], config)
-        self.assertIn("长句丢失换行", tran.problem,
-                      "更严的阈值应触发标记")
+        self.assertIn("长句丢失换行", tran.problem)
 
-    def test_skip_check_suppresses_detection(self):
-        """skip_check=True → 跳过全部检测 → 不应标记。"""
+    def test_skip_check_suppresses_detection(self) -> None:
         pre_src = "日本語の長い文章です。\nもっと続きます。"
         pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
         tran = make_tran(pre_src, pre_dst, skip_check=True)
         config = FakeProblemConfig()
         find_problems([tran], config)
-        self.assertEqual(tran.problem, "",
-                         "skip_check 应跳过所有检测")
+        self.assertEqual(tran.problem, "")
 
-    def test_skip_check_clears_existing_problem(self):
-        """skip_check=True → 即使之前有问题标记也应清除。"""
+    def test_skip_check_clears_existing_problem(self) -> None:
         pre_src = "日本語の長い文章です。\nもっと続きます。"
         pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
         tran = make_tran(pre_src, pre_dst, skip_check=True)
-        # 模拟之前遗留的问题标记
         tran.problem = "比日文长：1.5倍(10字符)"
         config = FakeProblemConfig(problem_list=["长句丢失换行", "比日文长"])
         find_problems([tran], config)
-        self.assertEqual(tran.problem, "",
-                         "skip_check 应清除已有问题标记")
+        self.assertEqual(tran.problem, "")
 
-    def test_disabled_in_problem_list_not_flagged(self):
-        """未启用长句丢失换行检测 → 即使译文很长也不标记。"""
+    def test_disabled_in_problem_list_not_flagged(self) -> None:
         pre_src = "日本語の長い文章です。\nもっと続きます。"
         pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
         tran = make_tran(pre_src, pre_dst)
-        # problemList 中没有"长句丢失换行"
         config = FakeProblemConfig(problem_list=["词频过高"])
         find_problems([tran], config)
-        self.assertNotIn("长句丢失换行", tran.problem,
-                         "未启用的检测项不应生效")
+        self.assertNotIn("长句丢失换行", tran.problem)
 
-    def test_source_without_linebreak_no_detection(self):
-        """原文无换行符 → n_symbol="" → 检测被跳过。"""
+    def test_source_without_linebreak_no_detection(self) -> None:
         pre_src = "日本語だけで改行がない。"
         pre_dst = "很长的一段中文翻译没有任何换行符分割句子即使很长也不会触发。"
         tran = make_tran(pre_src, pre_dst)
         config = FakeProblemConfig()
         find_problems([tran], config)
-        self.assertNotIn("长句丢失换行", tran.problem,
-                         "原文无换行时不应触发检测")
+        self.assertNotIn("长句丢失换行", tran.problem)
 
-    def test_avg_exceeds_threshold_by_large_margin(self):
-        """译文远超高阈值 → 应标记（边界值测试）。"""
+    def test_avg_exceeds_threshold_by_large_margin(self) -> None:
         pre_src = "文。\n文。\n文。\n"
-        # 译文有1个换行符，avg = clean / 2
-        pre_dst = "这是一句非常长的中文句子有一个换行符\n但还是太长。"  # len=25, clean=24, breaks=1, avg=24/2=12 > 8
+        pre_dst = "这是一句非常长的中文句子有一个换行符\n但还是太长。"
         tran = make_tran(pre_src, pre_dst)
         config = FakeProblemConfig(threshold=8)
         find_problems([tran], config)
-        self.assertIn("长句丢失换行", tran.problem,
-                      "avg=12 > 阈值8 应标记")
+        self.assertIn("长句丢失换行", tran.problem)
 
 
 if __name__ == "__main__":

--- a/tests/test_long_sentence_linebreak_detection.py
+++ b/tests/test_long_sentence_linebreak_detection.py
@@ -1,0 +1,155 @@
+"""测试"长句丢失换行"问题检测项。
+
+测试场景：
+- 译文分句过长（avg_sentence_length > threshold）应标记为"长句丢失换行"
+- 译文分句正常不应误标记
+- skip_check 可跳过该检测
+- 未启用该检测项时不触发
+
+设计前提：译文与原文使用同一种换行符（由 pre_src 推断的 n_symbol），
+因此检测直接复用 n_symbol 对 post_dst 计数，不处理"多换行符混用"场景。
+"""
+
+import unittest
+
+from GalTransl.Problem import find_problems
+from GalTransl.ConfigHelper import CProblemType
+from GalTransl.CSentense import CSentense
+
+
+class FakeProblemConfig:
+    """最小化的 projectConfig，用于驱动 find_problems。"""
+
+    target_lang = "zh-cn"
+
+    def __init__(self, problem_list=None, threshold=17):
+        self._problem_list = problem_list or ["长句丢失换行"]
+        self._threshold = threshold
+
+    def getProblemAnalyzeArinashiDict(self):
+        return {}
+
+    def getProblemAnalyzeConfig(self, key):
+        if key == "problemList":
+            return [CProblemType[name] for name in self._problem_list]
+        return []
+
+    def getlbSymbol(self):
+        return "auto"
+
+    def getAvgSentenceLengthThreshold(self):
+        return self._threshold
+
+
+def make_tran(pre_src: str, pre_dst: str, skip_check: bool = False) -> CSentense:
+    """构造一个 CSentense，原文带换行符以便触发检测。"""
+    tran = CSentense(pre_src, speaker="", index=0)
+    tran.post_src = pre_src
+    tran.pre_dst = pre_dst
+    tran.post_dst = pre_dst
+    tran.skip_check = skip_check
+    return tran
+
+
+class LongSentenceLinebreakDetectionTests(unittest.TestCase):
+    """长句丢失换行检测的单元测试。"""
+
+    def test_long_text_no_break_flagged(self):
+        """长译文且无换行符 → 平均分句长度 > 阈值 → 应标记。"""
+        # 原文带 \n 以便 n_symbol 被识别
+        pre_src = "日本語の長い文章です。\nもっと続きます。"
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"  # clean_len=24, breaks=0, avg=24/1=24 > 17
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertIn("长句丢失换行", tran.problem,
+                      "长译文无换行应被标记")
+
+    def test_short_text_no_break_not_flagged(self):
+        """短译文且无换行 → 平均分句长度 ≤ 阈值 → 不应标记。"""
+        pre_src = "ああ。\nそうですか。"
+        pre_dst = "总之，能再试试其他的服装吗？"  # len=14, breaks=0, avg=14/1=14 ≤ 17
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertNotIn("长句丢失换行", tran.problem,
+                         "短译文无换行不应标记")
+
+    def test_text_with_enough_breaks_not_flagged(self):
+        """译文有合理换行 → 平均分句长度正常 → 不应标记。"""
+        pre_src = "文A。\n文B。\n文C。"
+        pre_dst = "第一句。\n第二句。\n第三句。"  # len=14, clean=12, breaks=2, avg=12/3=4.0 ≤ 17
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertNotIn("长句丢失换行", tran.problem,
+                         "有合理换行的译文不应标记")
+
+    def test_custom_threshold_affects_result(self):
+        """自定义更紧的阈值 → 之前不触发的场景现在触发。"""
+        pre_src = "文。\n文。"
+        pre_dst = "合理长度的句子。\n另一句。\n再来一句。"  # len=19, clean=17, breaks=2, avg=17/3≈5.67
+        tran = make_tran(pre_src, pre_dst)
+        # 阈值设为 5，avg=5.67 > 5，应标记
+        config = FakeProblemConfig(threshold=5)
+        find_problems([tran], config)
+        self.assertIn("长句丢失换行", tran.problem,
+                      "更严的阈值应触发标记")
+
+    def test_skip_check_suppresses_detection(self):
+        """skip_check=True → 跳过全部检测 → 不应标记。"""
+        pre_src = "日本語の長い文章です。\nもっと続きます。"
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
+        tran = make_tran(pre_src, pre_dst, skip_check=True)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertEqual(tran.problem, "",
+                         "skip_check 应跳过所有检测")
+
+    def test_skip_check_clears_existing_problem(self):
+        """skip_check=True → 即使之前有问题标记也应清除。"""
+        pre_src = "日本語の長い文章です。\nもっと続きます。"
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
+        tran = make_tran(pre_src, pre_dst, skip_check=True)
+        # 模拟之前遗留的问题标记
+        tran.problem = "比日文长：1.5倍(10字符)"
+        config = FakeProblemConfig(problem_list=["长句丢失换行", "比日文长"])
+        find_problems([tran], config)
+        self.assertEqual(tran.problem, "",
+                         "skip_check 应清除已有问题标记")
+
+    def test_disabled_in_problem_list_not_flagged(self):
+        """未启用长句丢失换行检测 → 即使译文很长也不标记。"""
+        pre_src = "日本語の長い文章です。\nもっと続きます。"
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
+        tran = make_tran(pre_src, pre_dst)
+        # problemList 中没有"长句丢失换行"
+        config = FakeProblemConfig(problem_list=["词频过高"])
+        find_problems([tran], config)
+        self.assertNotIn("长句丢失换行", tran.problem,
+                         "未启用的检测项不应生效")
+
+    def test_source_without_linebreak_no_detection(self):
+        """原文无换行符 → n_symbol="" → 检测被跳过。"""
+        pre_src = "日本語だけで改行がない。"
+        pre_dst = "很长的一段中文翻译没有任何换行符分割句子即使很长也不会触发。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertNotIn("长句丢失换行", tran.problem,
+                         "原文无换行时不应触发检测")
+
+    def test_avg_exceeds_threshold_by_large_margin(self):
+        """译文远超高阈值 → 应标记（边界值测试）。"""
+        pre_src = "文。\n文。\n文。\n"
+        # 译文有1个换行符，avg = clean / 2
+        pre_dst = "这是一句非常长的中文句子有一个换行符\n但还是太长。"  # len=25, clean=24, breaks=1, avg=24/2=12 > 8
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig(threshold=8)
+        find_problems([tran], config)
+        self.assertIn("长句丢失换行", tran.problem,
+                      "avg=12 > 阈值8 应标记")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 后端

### 长句丢失换行检测
思路：通过检测平均分句长度avg_sentence_length的大小来判定是否缺失换行，若大于阀值则判为长句丢失换行，此方法能避免无需换行的过短句被判为问题句。
实践方法：新增检测项”长句丢失换行“：传入换行符字符数n_symbol.len()、换行符个数n_number、译文长度post_dst.len()，可算出纯文本的平均分句长度avg_sentence_length，若超过可配置阈值avgSentenceLengthThreshold（默认17）则判为长句丢失换行。
- 新增 CProblemType 枚举项，在 find_problems 中实现检测逻辑
- 阈值通过 config.yaml 的 avgSentenceLengthThreshold 配置（默认 17），getter 做了类型防御
- 此外，由于除换行符以外的控制符种类较多难以统计，且存在此类控制符的译文数量较少，avg_sentence_length的计算中没有计入此类控制符。**若因为此类控制符导致误报问题句，可通过skip_check 跳过检查来处理。**

### skip_check 跳过检查
思路：允许用户标记某句无需检查，勾选后立刻清除本句的问题标记，并在find_problem中跳过此句。
- CSentense 新增 skip_check 字段，Cache 层做好持久化与恢复
- server.py /cache/save 重建时读取 skip_check

## 前端

### 阈值配置
- 问题分析页新增数值输入框，本地校验输入类型，强制为int，合法后才写回 config

### skip_check 勾选
- 缓存页展开区增加复选框，勾选即时清除问题标记，折叠态显示 ⏭ 标识（此处emoji显示带有颜色且有边框，桌面端实测中该emoji为黑色无边框）
- api.ts 补充 skip_check 类型

## 测试
- 新增 2 个测试文件共 12 个用例：长句检测 9 个（阈值边界、skip 跳过、未启用不触发等），cache rebuild 流程 3 个
- 相关测试全部通过，全量 44 tests（42 passed + 2 上游既有 error），桌面端 tsc 零报错

 ### **我的代码水平不高，py相关知识了解不多，改动的代码由ai生成，ai检测，人工复查，应该不会有严重bug，但可能会有未发现的小bug，审查需谨慎**