### PR TITLE
fix: 修复删除语句时按钮失效

### DIFF
--- a/desktop/src/pages/ProjectCachePage.tsx
+++ b/desktop/src/pages/ProjectCachePage.tsx
@@ -42,7 +42,7 @@ function cloneEntries(entries: CacheEntry[]): CacheEntry[] {
   }));
 }
 function entriesMatch(left: CacheEntry[], right: CacheEntry[]): boolean {
-  const normalize = (items: CacheEntry[]) => items.map(({ deleted, ...entry }) => entry);
+  const normalize = (items: CacheEntry[]) => items.map((entry) => ({ ...entry, deleted: !!entry.deleted }));
   return JSON.stringify(normalize(left)) === JSON.stringify(normalize(right));
 }
 function escapeControlChars(text: string): string {


### PR DESCRIPTION
## 基于最新版本(v7.4.0)的恶性Bug：选择删除语句后不允许保存和撤销。
问题如图：
<img width="971" height="278" alt="1" src="https://github.com/user-attachments/assets/c9650895-0ac6-4e43-80f2-9fc0e86596d0" />

## 解决
只修改了一行代码，即 `normalize` 函数。
原来的逻辑是 `normalize` 在比较时移除了 `deleted`，因此只检测得到其它内容的差异，无法识别到用户选择删除语句。
顺带给当前文件的所有obj都加上 `deleted` 以使后续处理对象内容统一。
后端仍然不会保存 `deleted` ，只会在前端中临时处理时存在。
