### PR TITLE
feat: 新增单句过长检测与阈值可配置 (#205)

### DIFF
--- a/GalTransl/ConfigHelper.py
+++ b/GalTransl/ConfigHelper.py
@@ -14,6 +14,7 @@ from asyncio import gather
 from tenacity import retry, stop_after_attempt, wait_fixed
 import httpx
 import inspect
+import math
 from httpx import AsyncClient, TimeoutException
 from time import time
 from typing import Optional
@@ -22,6 +23,10 @@ from yaml import safe_load
 from os import path, sep
 from enum import Enum
 from importlib.metadata import version
+import re
+
+# 十进制数字字面量：拒下划线（float("1_000")=1000）等 Python 收而前端拒的写法
+_DECIMAL_LITERAL_RE = re.compile(r"^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$")
 
 
 def build_httpx_proxy_kwargs(proxy_addr: Optional[str]) -> dict:
@@ -109,6 +114,7 @@ class CProblemType(Enum):
     语言不通 = 10
     缺控制符 = 11
     独白男他 = 12
+    单句过长 = 13
 
 
 class CProjectConfig:
@@ -240,6 +246,28 @@ class CProjectConfig:
         elif not self.projectConfig["problemAnalyze"]["arinashiDict"]:
             return {}
         return self.projectConfig["problemAnalyze"]["arinashiDict"]
+
+    def getAvgSentenceLengthThreshold(self) -> int:
+        # 用户手改 config.yaml 可能写成 "17"(字符串) 或 17.5(浮点)，需强制转 int。
+        # 守卫与前端 resolveThreshold 完全对齐：拒 bool、拒非数字、拒非整数、拒 <=0，统一回退 17。
+        raw = self.projectConfig.get("problemAnalyze", {}).get(
+            "avgSentenceLengthThreshold", 17
+        )
+        if isinstance(raw, bool):
+            return 17
+        if isinstance(raw, str) and not _DECIMAL_LITERAL_RE.match(raw.strip()):
+            return 17
+        try:
+            f = float(raw)
+        except (TypeError, ValueError, OverflowError):
+            return 17
+        # 非整数值（如 17.5）直接拒绝，与前端 Number.isInteger 口径一致
+        if not math.isfinite(f) or not f.is_integer():
+            return 17
+        val = int(f)
+        if val <= 0:
+            return 17
+        return val
 
     def refreshProxyEnabledFlag(self) -> None:
         self.keyValues["internals.enableProxy"] = has_usable_proxy_config(

--- a/GalTransl/DefaultProjectConfig.py
+++ b/GalTransl/DefaultProjectConfig.py
@@ -95,6 +95,8 @@ problemAnalyze:
     - 独白男他 # 独白（无name）里出现“他”，排除“其他/他们/他人/他乡/他国/他日/他山”
     #- 引入英文 # 本来没有英文，译文引入了英文
     #- 比日文长严格 # 比日文长1倍以上就提醒
+    #- 单句过长 # 平均分句长度超过阈值（avgSentenceLengthThreshold），单句过长
+  avgSentenceLengthThreshold: 17 # 单句过长的分句长度阈值，默认17，建议范围15~25
 
 # 字典设置
 dictionary:

--- a/GalTransl/Problem.py
+++ b/GalTransl/Problem.py
@@ -108,6 +108,14 @@ def find_problems(
         if CProblemType.丢失换行 in find_type and n_symbol != "":
             if pre_src.count(n_symbol) > post_dst.count(n_symbol):
                 problem_list.append("丢失换行")
+        if CProblemType.单句过长 in find_type and n_symbol != "":
+            n_number = post_dst.count(n_symbol)
+            # 去除换行符本身的字符长度，只计算纯文本
+            clean_len = len(post_dst) - n_number * len(n_symbol)
+            avg_sentence_length = clean_len / (n_number + 1)
+            threshold = projectConfig.getAvgSentenceLengthThreshold()
+            if avg_sentence_length > threshold:
+                problem_list.append("单句过长")
         if CProblemType.多加换行 in find_type and n_symbol != "":
             if pre_src.count(n_symbol) < post_dst.count(n_symbol):
                 problem_list.append("多加换行")

--- a/GalTransl/server.py
+++ b/GalTransl/server.py
@@ -428,6 +428,7 @@ _PROBLEM_TYPE_CATALOG: list[dict[str, str]] = [
     {"name": "语言不通", "description": "译文包含大量非 GBK 字符（仅对中文目标语言生效）。"},
     {"name": "缺控制符", "description": "译文缺少原文中的控制符（如 \\n、变量标记等）。"},
     {"name": "独白男他", "description": "独白（无name）译文出现'他'。"},
+    {"name": "单句过长", "description": "译文单句过长，平均分句长度超过阈值（avgSentenceLengthThreshold）。"},
 ]
 
 

--- a/desktop/src/pages/ProjectConfigPage.tsx
+++ b/desktop/src/pages/ProjectConfigPage.tsx
@@ -376,6 +376,13 @@ export function ProjectConfigPage({ ctx }: { ctx: ProjectPageContext }) {
                       return prev ? { ...prev, problemAnalyze: pa } : prev;
                     });
                   }}
+                  onThresholdChange={(value) => {
+                    setConfig((prev) => {
+                      const pa = { ...((prev?.problemAnalyze as Record<string, unknown>) || {}) };
+                      pa.avgSentenceLengthThreshold = value;
+                      return prev ? { ...prev, problemAnalyze: pa } : prev;
+                    });
+                  }}
                   onDirty={() => { setSaveSuccess(false); setDirty(true); }}
                 />
               )}

--- a/desktop/src/pages/project-config/ProblemAnalyzeSection.tsx
+++ b/desktop/src/pages/project-config/ProblemAnalyzeSection.tsx
@@ -5,6 +5,7 @@ import { fetchProblemTypes, type ProblemTypeInfo } from '../../lib/api';
 interface ProblemAnalyzeSectionProps {
   config: Record<string, unknown> | null;
   onProblemListChange: (lines: string[]) => void;
+  onThresholdChange: (value: number) => void;
   onDirty: () => void;
 }
 
@@ -20,7 +21,24 @@ function readProblemList(config: Record<string, unknown> | null): string[] {
   return [];
 }
 
-export function ProblemAnalyzeSection({ config, onProblemListChange, onDirty }: ProblemAnalyzeSectionProps) {
+const DEFAULT_THRESHOLD = 17;
+// 十进制数字字面量：Number() 会接受 "0x10"/"Infinity" 等后端 float() 会拒的写法
+const DECIMAL_LITERAL_RE = /^[+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/;
+
+// 与后端 CProjectConfig.getAvgSentenceLengthThreshold 守卫口径逐条对齐：
+// 拒布尔、拒非十进制字面量、拒非有限数、拒非整数、拒 <=0（统一回退 17）。
+function resolveThreshold(config: Record<string, unknown> | null): number {
+  const pa = (config?.problemAnalyze as Record<string, unknown>) || {};
+  const raw = pa.avgSentenceLengthThreshold;
+  if (typeof raw === 'boolean') return DEFAULT_THRESHOLD;
+  if (typeof raw === 'string' && !DECIMAL_LITERAL_RE.test(raw.trim())) return DEFAULT_THRESHOLD;
+  const f = Number(raw);
+  if (!Number.isFinite(f) || !Number.isInteger(f)) return DEFAULT_THRESHOLD;
+  if (f <= 0) return DEFAULT_THRESHOLD;
+  return f;
+}
+
+export function ProblemAnalyzeSection({ config, onProblemListChange, onThresholdChange, onDirty }: ProblemAnalyzeSectionProps) {
   const [problemTypes, setProblemTypes] = useState<ProblemTypeInfo[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -43,6 +61,37 @@ export function ProblemAnalyzeSection({ config, onProblemListChange, onDirty }: 
 
   const selected = useMemo(() => readProblemList(config), [config]);
   const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const threshold = useMemo(() => resolveThreshold(config), [config]);
+
+  // 本地输入态：保留用户输入的原始字符串（含空串 / 非整数等中间态），
+  // 以便对阈值类型做实时检测与提示，而不是直接吞掉非法输入。
+  const [thresholdInput, setThresholdInput] = useState<string>(String(threshold));
+  const [thresholdError, setThresholdError] = useState<string | null>(null);
+
+  // 依赖必须是 config 而非 threshold：阈值数值未变时（如两个项目都默认 17）
+  // 依赖 threshold 会让上一项目的错误输入与提示残留到新项目。
+  useEffect(() => {
+    setThresholdInput(String(resolveThreshold(config)));
+    setThresholdError(null);
+  }, [config]);
+
+  const validateAndCommitThreshold = (raw: string) => {
+    setThresholdInput(raw);
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      setThresholdError('阈值不能为空，请输入大于 0 的整数');
+      return;
+    }
+    const v = Number(trimmed);
+    if (!Number.isInteger(v) || v <= 0) {
+      setThresholdError('阈值类型无效：请输入大于 0 的整数');
+      return;
+    }
+    setThresholdError(null);
+    onThresholdChange(v);
+    onDirty();
+  };
 
   // Keep entries the user already has in config even if backend doesn't list them
   // (e.g. future types or custom strings); render them at the bottom.
@@ -172,6 +221,29 @@ export function ProblemAnalyzeSection({ config, onProblemListChange, onDirty }: 
                 </li>
               ))}
             </ul>
+
+            <div className="problem-analyze-section__threshold">
+              <label className="problem-analyze-section__threshold-label">
+                <span>长句判定阈值（avgSentenceLengthThreshold）</span>
+                <input
+                  type="number"
+                  className={`problem-analyze-section__threshold-input${thresholdError ? ' problem-analyze-section__threshold-input--error' : ''}`}
+                  min={1}
+                  max={99}
+                  value={thresholdInput}
+                  onChange={(e) => validateAndCommitThreshold(e.target.value)}
+                  onBlur={(e) => validateAndCommitThreshold(e.target.value)}
+                />
+              </label>
+              <span className="problem-analyze-section__threshold-desc">
+                译文平均分句长度超过此值时标记为"单句过长"。默认 17，建议范围 15~25。
+              </span>
+              {thresholdError && (
+                <span className="problem-analyze-section__threshold-error">
+                  {thresholdError}
+                </span>
+              )}
+            </div>
           </>
         )}
       </div>

--- a/desktop/src/styles/pages/project-config.css
+++ b/desktop/src/styles/pages/project-config.css
@@ -553,6 +553,57 @@
   color: #a16207;
 }
 
+.problem-analyze-section__threshold {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-line);
+}
+
+.problem-analyze-section__threshold-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.problem-analyze-section__threshold-label > span {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.problem-analyze-section__threshold-input {
+  width: 72px;
+  min-height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-control);
+  font-size: 13px;
+  color: var(--color-text);
+  background: var(--color-neutral-soft, transparent);
+}
+
+.problem-analyze-section__threshold-input:focus {
+  outline: none;
+  border-color: var(--color-primary, var(--color-line));
+}
+
+.problem-analyze-section__threshold-input--error {
+  border-color: #c53030;
+}
+
+.problem-analyze-section__threshold-desc {
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.problem-analyze-section__threshold-error {
+  font-size: 11.5px;
+  color: #c53030;
+}
+
 /* ── Retransl Key Section ── */
 
 .retransl-key-section {

--- a/tests/test_single_sentence_too_long.py
+++ b/tests/test_single_sentence_too_long.py
@@ -1,0 +1,132 @@
+import unittest
+
+from GalTransl.Problem import find_problems
+from GalTransl.ConfigHelper import CProblemType, CProjectConfig
+from GalTransl.CSentense import CSentense
+
+
+class FakeProblemConfig:
+    target_lang = "zh-cn"
+
+    def __init__(self, problem_list=None, threshold=17):
+        self._problem_list = problem_list or ["单句过长"]
+        self._threshold = threshold
+
+    def getProblemAnalyzeArinashiDict(self):
+        return {}
+
+    def getProblemAnalyzeConfig(self, key):
+        if key == "problemList":
+            return [CProblemType[name] for name in self._problem_list]
+        return []
+
+    def getlbSymbol(self):
+        return "auto"
+
+    def getAvgSentenceLengthThreshold(self):
+        return self._threshold
+
+
+def make_tran(pre_src: str, pre_dst: str) -> CSentense:
+    tran = CSentense(pre_src, speaker="", index=0)
+    tran.post_src = pre_src
+    tran.pre_dst = pre_dst
+    tran.post_dst = pre_dst
+    return tran
+
+
+class SingleSentenceTooLongTests(unittest.TestCase):
+
+    def test_long_text_no_break_flagged(self) -> None:
+        pre_src = "日本語の長い文章です。\nもっと続きます。"
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertIn("单句过长", tran.problem)
+
+    def test_short_text_no_break_not_flagged(self) -> None:
+        pre_src = "ああ。\nそうですか。"
+        pre_dst = "总之，能再试试其他的服装吗？"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertNotIn("单句过长", tran.problem)
+
+    def test_text_with_enough_breaks_not_flagged(self) -> None:
+        pre_src = "文A。\n文B。\n文C。"
+        pre_dst = "第一句。\n第二句。\n第三句。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertNotIn("单句过长", tran.problem)
+
+    def test_custom_threshold_affects_result(self) -> None:
+        pre_src = "文。\n文。"
+        pre_dst = "合理长度的句子。\n另一句。\n再来一句。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig(threshold=5)
+        find_problems([tran], config)
+        self.assertIn("单句过长", tran.problem)
+
+    def test_disabled_in_problem_list_not_flagged(self) -> None:
+        pre_src = "日本語の長い文章です。\nもっと続きます。"
+        pre_dst = "这是一句很长的中文翻译没有任何换行符来分割句子。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig(problem_list=["词频过高"])
+        find_problems([tran], config)
+        self.assertNotIn("单句过长", tran.problem)
+
+    def test_source_without_linebreak_no_detection(self) -> None:
+        pre_src = "日本語だけで改行がない。"
+        pre_dst = "很长的一段中文翻译没有任何换行符分割句子即使很长也不会触发。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig()
+        find_problems([tran], config)
+        self.assertNotIn("单句过长", tran.problem)
+
+    def test_avg_exceeds_threshold_by_large_margin(self) -> None:
+        pre_src = "文。\n文。\n文。\n"
+        pre_dst = "这是一句非常长的中文句子有一个换行符\n但还是太长。"
+        tran = make_tran(pre_src, pre_dst)
+        config = FakeProblemConfig(threshold=8)
+        find_problems([tran], config)
+        self.assertIn("单句过长", tran.problem)
+
+
+class ThresholdGuardTests(unittest.TestCase):
+    """阈值取值守卫，每个取值都需与前端 resolveThreshold 保持一致"""
+
+    def threshold_of(self, raw: object) -> int:
+        # 绕过 __init__（它依赖真实项目目录），只注入待校验的配置片段
+        cfg = CProjectConfig.__new__(CProjectConfig)
+        cfg.projectConfig = {"problemAnalyze": {"avgSentenceLengthThreshold": raw}}
+        return cfg.getAvgSentenceLengthThreshold()
+
+    def test_valid_values_are_accepted(self) -> None:
+        self.assertEqual(self.threshold_of(17), 17)
+        self.assertEqual(self.threshold_of("17"), 17)
+        self.assertEqual(self.threshold_of(20.0), 20)
+        self.assertEqual(self.threshold_of(" 17 "), 17)
+        self.assertEqual(self.threshold_of("1e1"), 10)
+
+    def test_non_integer_falls_back_to_default(self) -> None:
+        # 非整数一律回退 17（与前端 Number.isInteger 口径一致），不再 half-up 舍入
+        for raw in [17.5, 2.5, 16.5, "17.5", 0.4, -0.4]:
+            self.assertEqual(self.threshold_of(raw), 17, f"raw={raw!r}")
+
+    def test_invalid_values_fallback_to_default(self) -> None:
+        for raw in [True, False, 0, -5, None, "", "abc", "0x10", "1_000", "1_0",
+                    "Infinity", "nan", float("inf"), float("nan"), 1e309]:
+            self.assertEqual(self.threshold_of(raw), 17, f"raw={raw!r}")
+
+    def test_missing_key_fallback_to_default(self) -> None:
+        cfg = CProjectConfig.__new__(CProjectConfig)
+        cfg.projectConfig = {"problemAnalyze": {}}
+        self.assertEqual(cfg.getAvgSentenceLengthThreshold(), 17)
+        cfg.projectConfig = {}
+        self.assertEqual(cfg.getAvgSentenceLengthThreshold(), 17)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
本 PR 由 #206 拆分而来。
聚焦"平均分句长度超过阈值"的检测（单句过长）与阈值可配置，不涉及 #206 中的 skip_check 改动。

## 改动

### 后端
- `GalTransl/ConfigHelper.py`：`CProblemType` 新增「单句过长」；新增 `getAvgSentenceLengthThreshold()`，
  对配置值做取值守卫（拒 bool / 非有限数 / 非整数 / ≤0，统一回退默认 17），
  与前端 `resolveThreshold` 口径完全一致（含边界字面量）。
- `GalTransl/Problem.py`：新增检测——译文平均分句长度超过阈值时标记「单句过长」；
  沿用既有"原文无换行不检测"的门控。
- `GalTransl/DefaultProjectConfig.py`：新增 `avgSentenceLengthThreshold: 17` 默认配置；
  `problemList` 增加注释行「单句过长」（默认不启用，用户在项目配置中勾选后生效）。
- `GalTransl/server.py`：问题类型目录新增条目，供前端问题类型列表展示。

### 前端
- `desktop/src/pages/project-config/ProblemAnalyzeSection.tsx`、`ProjectConfigPage.tsx`：
  阈值输入框 + 实时校验（非法输入即时提示、保存时整体写回 yaml）。
- `desktop/src/styles/pages/project-config.css`：阈值输入区样式（含错误态）。
- `tests/test_single_sentence_too_long.py`：11 例（7 例检测行为 + 4 例阈值取值守卫）。

## 验证

- Python unittest：11/11 通过
- 前端 `tsc --noEmit`：零报错
- 前后端阈值守卫：从 tsx 源码提取真实 `resolveThreshold` 与后端逐值比对
  33 项（含 `17.5`、`"1_000"`、`Infinity`、`NaN` 等边界），完全一致

## 使用

项目配置 →「问题检测」勾选「单句过长」，阈值默认 17，可实时调整。
