### PR TITLE
feat: 新增 skip_check 跳过检查机制 (#205)

### DIFF
--- a/GalTransl/CSentense.py
+++ b/GalTransl/CSentense.py
@@ -39,6 +39,7 @@ class CSentense:
         self.proofread_by = ""  # 校对记录
 
         self.problem = ""  # 问题记录
+        self.skip_check = False  # 跳过问题检查
         self.trans_conf = 0.0  # 翻译可信度 For GPT4
         self.doub_content = ""  # 用于记录疑问句的内容 For GPT4
         self.unknown_proper_noun = ""  # 用于记录未知的专有名词 For GPT4

--- a/GalTransl/Cache.py
+++ b/GalTransl/Cache.py
@@ -134,6 +134,9 @@ def _build_cache_obj(tran, post_save: bool = False):
     if post_save and tran.problem != "":
         cache_obj["problem"] = tran.problem
 
+    if getattr(tran, "skip_check", False):
+        cache_obj["skip_check"] = True
+
     cache_obj["trans_by"] = tran.trans_by
     cache_obj["proofread_by"] = tran.proofread_by
 
@@ -501,6 +504,8 @@ async def get_transCache_from_json(
             tran.doub_content = cache_dict[cache_key]["doub_content"]
         if "unknown_proper_noun" in cache_dict[cache_key]:
             tran.unknown_proper_noun = cache_dict[cache_key]["unknown_proper_noun"]
+        if "skip_check" in cache_dict[cache_key]:
+            tran.skip_check = bool(cache_dict[cache_key]["skip_check"])
 
         if tran.proofread_zh != "":
             tran.post_dst = tran.proofread_zh

--- a/GalTransl/Problem.py
+++ b/GalTransl/Problem.py
@@ -47,6 +47,10 @@ def find_problems(
         find_type = projectConfig.getProblemAnalyzeConfig("GPT35")  # 兼容旧版
 
     for tran in trans_list:
+        if getattr(tran, "skip_check", False):
+            tran.problem = ""
+            continue
+
         pre_src = tran.pre_src
         post_src = tran.post_src
         pre_dst = tran.pre_dst

--- a/GalTransl/server.py
+++ b/GalTransl/server.py
@@ -1052,6 +1052,7 @@ def build_handler(registry: JobRegistry):
                             s.trans_conf = e.get("trans_conf", 0)
                             s.doub_content = e.get("doub_content", "")
                             s.unknown_proper_noun = e.get("unknown_proper_noun", "")
+                            s.skip_check = bool(e.get("skip_check", False))
                             trans_list.append(s)
 
                         # Link prev/next

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -104,6 +104,7 @@ export type CacheEntry = {
   trans_by?: string;
   proofread_by?: string;
   problem?: string;
+  skip_check?: boolean;
   trans_conf?: number;
   doub_content?: string;
   unknown_proper_noun?: string;

--- a/desktop/src/pages/ProjectCachePage.tsx
+++ b/desktop/src/pages/ProjectCachePage.tsx
@@ -82,7 +82,7 @@ function CacheEntryCard({
   entry: CacheEntry;
   filename: string;
   projectId: string;
-  onEntryChange: (index: number, field: keyof CacheEntry, value: string) => void;
+  onEntryChange: (index: number, field: keyof CacheEntry, value: string | boolean) => void;
   onDelete: (index: number) => void;
   highlightQuery?: string;
   nameDict: Map<string, string>;
@@ -109,6 +109,9 @@ function CacheEntryCard({
           </div>
         )}
         <div className="cache-card__spacer" />
+        {entry.skip_check && (
+          <span className="cache-card__pill cache-card__pill--skip-check" title="已跳过问题检查">⏭</span>
+        )}
         {entry.trans_by && (
           <span className="cache-card__pill cache-card__pill--engine">{entry.trans_by}</span>
         )}
@@ -205,6 +208,16 @@ function CacheEntryCard({
               <div className="cache-card__readonly-textarea">
                 {escapeControlChars(entry.post_dst_preview || entry.post_zh_preview || '')}
               </div>
+            </div>
+            <div className="cache-card__field cache-card__field--skip-check">
+              <label className="cache-card__checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={!!entry.skip_check}
+                  onChange={(e) => onEntryChange(entry.index, 'skip_check', e.target.checked)}
+                />
+                <span>跳过检查（skip_check）</span>
+              </label>
             </div>
           </>
         )}
@@ -769,9 +782,17 @@ export function ProjectCachePage({ ctx, active = true }: { ctx: ProjectPageConte
   const translated = entries.filter((e) => dst(e)).length;
   const withProblems = entries.filter((e) => e.problem).length;
 
-  const handleEntryChange = (index: number, field: keyof CacheEntry, value: string) => {
+  const handleEntryChange = (index: number, field: keyof CacheEntry, value: string | boolean) => {
     setEntries((prev) => {
-      const next = prev.map((e) => (e.index === index ? { ...e, [field]: value } : e));
+      const next = prev.map((e) => {
+        if (e.index !== index) return e;
+        const updated = { ...e, [field]: value };
+        // 勾选跳过检查时同步清除问题标记
+        if (field === 'skip_check' && value === true) {
+          updated.problem = '';
+        }
+        return updated;
+      });
       if (selectedFile) entriesMapRef.current.set(selectedFile, next);
       return next;
     });

--- a/desktop/src/styles/pages/project-cache.css
+++ b/desktop/src/styles/pages/project-cache.css
@@ -557,6 +557,12 @@
   white-space: nowrap;
 }
 
+.cache-card__pill--skip-check {
+  background: var(--color-neutral-soft);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
 .cache-card__expand,
 .cache-card__delete {
   flex-shrink: 0;
@@ -726,6 +732,30 @@
   cursor: default;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.cache-card__field--skip-check {
+  padding-top: var(--space-1);
+  border-top: 1px dashed var(--color-line);
+}
+
+.cache-card__checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--cache-font-xs);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.cache-card__checkbox-label input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+.cache-card__checkbox-label:hover {
+  color: var(--color-text);
 }
 
 .cache-panel-actions {

--- a/tests/test_cache_save_respects_skip_check.py
+++ b/tests/test_cache_save_respects_skip_check.py
@@ -1,0 +1,157 @@
+import unittest
+
+from GalTransl.CSentense import CSentense
+from GalTransl.Problem import find_problems
+
+
+class FakeProblemConfig:
+    target_lang = "zh-cn"
+
+    def __init__(self, problem_list=None):
+        # 使用 BASE 已存在的检测项，避免依赖 feature-1（单句过长）的枚举成员
+        self._problem_list = problem_list or ["比日文长严格"]
+
+    def getProblemAnalyzeArinashiDict(self):
+        return {}
+
+    def getProblemAnalyzeConfig(self, key):
+        if key == "problemList":
+            from GalTransl.Problem import CProblemType
+            return [CProblemType[name] for name in self._problem_list]
+        return []
+
+    def getlbSymbol(self):
+        return "auto"
+
+
+def rebuild_entries(entries, config):
+    trans_list = []
+    for e in entries:
+        speaker = e.get("name", "")
+        if isinstance(speaker, list):
+            speaker = "/".join(speaker)
+        pre_src = e.get("pre_src", "") or e.get("pre_jp", "")
+        post_src = e.get("post_src", "") or e.get("post_jp", "")
+        pre_dst = e.get("pre_dst", "") or e.get("pre_zh", "")
+        proofread_dst = e.get("proofread_dst", "") or e.get("proofread_zh", "")
+        if post_src == "":
+            continue
+        s = CSentense(pre_src, speaker if speaker else "", e.get("index", 0))
+        s.post_src = pre_src
+        s.pre_dst = pre_dst
+        s.proofread_zh = proofread_dst
+        s.post_dst = proofread_dst if proofread_dst else pre_dst
+        s.trans_by = e.get("trans_by", "")
+        s.proofread_by = e.get("proofread_by", "")
+        s.trans_conf = e.get("trans_conf", 0)
+        s.doub_content = e.get("doub_content", "")
+        s.unknown_proper_noun = e.get("unknown_proper_noun", "")
+        s.skip_check = bool(e.get("skip_check", False))
+        trans_list.append(s)
+
+    for i, s in enumerate(trans_list):
+        if i > 0:
+            s.prev_tran = trans_list[i - 1]
+        if i < len(trans_list) - 1:
+            s.next_tran = trans_list[i + 1]
+
+    if trans_list:
+        find_problems(trans_list, config, None)
+
+    idx = 0
+    for e in entries:
+        post_src_val = e.get("post_src", "") or e.get("post_jp", "")
+        if post_src_val == "":
+            continue
+        if idx < len(trans_list):
+            tran = trans_list[idx]
+            if tran.problem:
+                e["problem"] = tran.problem
+            elif "problem" in e:
+                del e["problem"]
+            e["post_dst_preview"] = tran.post_dst
+            idx += 1
+
+    return entries
+
+
+SRC_WITH_BREAK = "日本語の長い文章です。\nもっと続きますよ。"
+DST_LONG_NO_BREAK = "这是一句非常长的中文翻译完全没有换行符来分割整句话。"
+
+
+class TestCacheSaveRespectsSkipCheck(unittest.TestCase):
+    def _make_entry(self, skip_check, problem=""):
+        return {
+            "index": 0,
+            "name": "",
+            "pre_src": SRC_WITH_BREAK,
+            "post_src": SRC_WITH_BREAK,
+            "pre_dst": DST_LONG_NO_BREAK,
+            "proofread_dst": DST_LONG_NO_BREAK,
+            "skip_check": skip_check,
+            "problem": problem,
+        }
+
+    def test_skip_check_prevents_rebuild_flagging(self) -> None:
+        entry = self._make_entry(skip_check=True, problem="")
+        entries = rebuild_entries([entry], FakeProblemConfig())
+        self.assertNotIn("problem", entries[0])
+        self.assertTrue(entries[0]["skip_check"])
+
+    def test_no_skip_check_still_flagged(self) -> None:
+        entry = self._make_entry(skip_check=False, problem="")
+        entries = rebuild_entries([entry], FakeProblemConfig())
+        self.assertIn("problem", entries[0])
+        self.assertIn("比日文长", entries[0]["problem"])
+
+    def test_skip_check_clears_existing_problem(self) -> None:
+        entry = self._make_entry(skip_check=True, problem="残留日文")
+        entries = rebuild_entries([entry], FakeProblemConfig())
+        self.assertNotIn("problem", entries[0])
+
+    def test_build_cache_obj_only_writes_skip_check_when_true(self) -> None:
+        from GalTransl.Cache import _build_cache_obj
+
+        tran = CSentense(SRC_WITH_BREAK, speaker="", index=0)
+        tran.post_src = SRC_WITH_BREAK
+        tran.pre_dst = DST_LONG_NO_BREAK
+        tran.post_dst = DST_LONG_NO_BREAK
+        self.assertNotIn("skip_check", _build_cache_obj(tran))
+        tran.skip_check = True
+        self.assertIs(_build_cache_obj(tran).get("skip_check"), True)
+
+    def test_read_cache_normalizes_skip_check_to_bool(self) -> None:
+        import asyncio
+        import json
+        import os
+        import tempfile
+
+        from GalTransl.Cache import get_transCache_from_json
+
+        # bool() 语义：非空字符串恒为真（"false" 亦为 True），0 / 空串 / None 为假。
+        # 本用例锁定读出的值一定是真正的 bool，而不是缓存里存的原始类型。
+        for raw_value, expected in [("false", True), ("true", True), (1, True), (0, False)]:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                cache_path = os.path.join(tmp_dir, "cache.json")
+                entry = {
+                    "index": 0,
+                    "name": "",
+                    "pre_src": SRC_WITH_BREAK,
+                    "post_src": SRC_WITH_BREAK,
+                    "pre_dst": DST_LONG_NO_BREAK,
+                    "post_dst": DST_LONG_NO_BREAK,
+                    "trans_by": "unit-test",
+                    "skip_check": raw_value,
+                }
+                with open(cache_path, "w", encoding="utf8") as f:
+                    json.dump([entry], f)
+                tran = CSentense(SRC_WITH_BREAK, speaker="", index=0)
+                tran.post_src = SRC_WITH_BREAK
+                asyncio.run(get_transCache_from_json([tran], cache_path))
+            # trans_by 被读到说明缓存确实命中，否则下面的断言是假通过
+            self.assertEqual(tran.trans_by, "unit-test", f"缓存未命中，用例 {raw_value!r} 无效")
+            self.assertIs(tran.skip_check, expected, f"raw={raw_value!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
聚焦「跳过问题检查」机制：允许对单个缓存条目标记 skip_check，
使其在问题检测与缓存重建时被跳过，不涉及 #206 中的单句过长检测改动。

## 改动

### 后端
- `GalTransl/CSentense.py`：`CSentense` 新增 `skip_check = False` 字段。
- `GalTransl/Problem.py`：`find_problems` 对 `skip_check` 为真的句子跳过全部检测，
  并清空其已有 `problem` 标记。
- `GalTransl/Cache.py`：写缓存时仅 `skip_check` 为真才写入该键（普通条目不落盘，
  缓存文件体积/结构不变）；读缓存时统一归一为 `bool`。
- `GalTransl/server.py`：保存缓存重建时读取 `skip_check` 回填到句子对象，
  重建后移除 `problem` 字段。

### 前端
- `desktop/src/lib/api.ts`：`CacheEntry` 新增可选 `skip_check` 字段。
- `desktop/src/pages/ProjectCachePage.tsx`：缓存卡片显示「跳过检查」标记；
  展开区提供 checkbox 勾选/取消，勾选时同步清除该条 `problem` 并标记脏。
- `desktop/src/styles/pages/project-cache.css`：标记 pill、分隔线、checkbox 样式。
- `tests/test_cache_save_respects_skip_check.py`：5 例
  （跳过生效 / 未跳过仍标记 / 勾选清除旧 problem / 仅真值写盘 / 读缓存归一）。

## 验证

- Python unittest：5/5 通过
- 前端 `tsc --noEmit`：零报错

## 使用

校对缓存页展开条目 → 勾选「跳过检查」→ 保存；该条不再参与问题检测。
取消勾选并保存后恢复检测。
